### PR TITLE
Add the @truffle/hdwallet-provider dep in readme and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git checkout start && npm i
 ```
 
 This will install the following packages we have already included:
-`ethers polished styled-components use-immer ncp dotenv @openzeppelin/contracts base64-sol ncp truffle-contract-size`
+`ethers polished styled-components use-immer ncp dotenv @openzeppelin/contracts base64-sol ncp truffle-contract-size @truffle/hdwallet-provider`
 
 Run `npm start` and ensure that you get a standard React Projects with no errors in the terminal or in the browser console. You should see a fairly blank application and no errors in the console.
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-scripts": "5.0.0",
     "styled-components": "^5.3.3",
     "truffle-contract-size": "^2.0.1",
+    "@truffle/hdwallet-provider": "^2.0.4",
     "use-immer": "^0.6.0",
     "web-vitals": "^2.1.4"
   },


### PR DESCRIPTION
Fixes an issue with the missing dependency.